### PR TITLE
Fix config path as per XDG spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ Keybinding                                          | Description
 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>i</kbd>       | Increment number of master windows
 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>d</kbd>       | Decrement number of master windows
 
-**Note:** Zentile has been tested on Openbox. It should work with any ewmh complaint window manager.
+The config file is located at `~/.config/zentile/config.toml`
 
-### Known Bugs
-Zentile doesn't work well when iconify animation is enabled in Openbox.
+**Note:** Zentile has been tested on Openbox. It should work with any EWMH complaint window manager.
 
 ### Credits
 

--- a/config.go
+++ b/config.go
@@ -41,7 +41,7 @@ func configFolderPath() string {
 	case "linux":
 		xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 		if xdgConfigHome != "" {
-			configFolder = xdgConfigHome
+			configFolder = filepath.Join(xdgConfigHome, "zentile")
 		} else {
 			configFolder, _ = homedir.Expand("~/.config/zentile/")
 		}


### PR DESCRIPTION
XDG_CONFIG_HOME/config.toml was being used as the path for config file. 
Changed this to XDG_CONFIG_HOME/zentile/config.toml