### PR TITLE
Fix crash of pinned windows

### DIFF
--- a/store.go
+++ b/store.go
@@ -67,6 +67,9 @@ func (st *Store) DecreaseMaster() {
 }
 
 func (st *Store) MakeMaster(c Client) {
+	if c.window == nil {
+		return
+	}
 	for i, slave := range st.slaves {
 		if slave.window.Id == c.window.Id {
 			st.masters[0], st.slaves[i] = st.slaves[i], st.masters[0]

--- a/tracker.go
+++ b/tracker.go
@@ -108,14 +108,20 @@ func (tr *tracker) handleDesktopChange(c *Client) {
 	newDesk, _ := ewmh.WmDesktopGet(state.X, c.window.Id)
 	oldDesk := c.Desk
 
+	// Remove client window from old desktop
 	tr.workspaces[oldDesk].RemoveClient(*c)
-	tr.workspaces[newDesk].AddClient(*c)
-
-	c.Desk = newDesk
 	if tr.workspaces[oldDesk].IsTiling {
 		tr.workspaces[oldDesk].Tile()
 	}
 
+	// Ignore "Always On Visible Workspace" windows on desktop 4294967295 (max uint32)
+	if newDesk > state.DeskCount {
+		return
+	}
+	c.Desk = newDesk
+
+	// Add client window to new desktop
+	tr.workspaces[newDesk].AddClient(*c)
 	if tr.workspaces[newDesk].IsTiling {
 		tr.workspaces[newDesk].Tile()
 	} else {


### PR DESCRIPTION
Fixes two issues that leads to a zentile crash:
- Set window to "Always on Visible Workspace".
- Make the active, but untracked (ignored, pinned) window a master.
