### PR TITLE
status file to track desktop tiling state

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,8 +18,9 @@ type cfg struct {
 	WindowsToIgnore []string `toml:"ignore"`
 	Gap             int
 	Proportion      float64
-	HideDecor       bool  `toml:"remove_decorations"`
-	TileStartup     []int `toml:"tile_workspaces"`
+	TileStartup     []int  `toml:"tile_workspaces"`
+	HideDecor       bool   `toml:"remove_decorations"`
+	StatusFname     string `toml:"status_filename"`
 }
 
 func init() {
@@ -77,6 +78,10 @@ proportion = 0.1
 # tile on startup (optional)
 # list of workspace numbers to activate tiling for at startup
 # tile_workspaces = [0, 1, 3]
+
+# write out tiling status as it changes (optional)
+# use the full path to the file
+# status_filename = "/full/path/to/file"
 
 [keybindings]
 # key sequences can have zero or more modifiers and exactly one key.

--- a/keybinding.go
+++ b/keybinding.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+
 	"github.com/BurntSushi/xgbutil"
 	"github.com/BurntSushi/xgbutil/keybind"
 	"github.com/BurntSushi/xgbutil/xevent"
@@ -22,19 +25,36 @@ func (k keyMapper) bind(action string, f func()) {
 	}
 }
 
+func generateStatus(t *tracker) {
+	fname := Config.StatusFname
+	if fname == "" {
+		return
+	}
+
+	blob, _ := json.MarshalIndent(t.workspaces, "", "    ")
+	os.Create(fname)
+	err := os.WriteFile(fname, blob, 0600)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 func bindKeys(t *tracker) {
 	workspaces := t.workspaces
 	keybind.Initialize(state.X)
 	k := keyMapper{}
+	generateStatus(t)
 
 	k.bind("tile", func() {
 		ws := workspaces[state.CurrentDesk]
 		ws.IsTiling = true
 		ws.Tile()
+		generateStatus(t)
 	})
 	k.bind("untile", func() {
 		ws := workspaces[state.CurrentDesk]
 		ws.Untile()
+		generateStatus(t)
 	})
 	k.bind("make_active_window_master", func() {
 		c := t.clients[state.ActiveWin]

--- a/keybinding.go
+++ b/keybinding.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-	"os"
-
 	"github.com/BurntSushi/xgbutil"
 	"github.com/BurntSushi/xgbutil/keybind"
 	"github.com/BurntSushi/xgbutil/xevent"
@@ -22,20 +19,6 @@ func (k keyMapper) bind(action string, f func()) {
 
 	if err != nil {
 		log.Warn(err)
-	}
-}
-
-func generateStatus(t *tracker) {
-	fname := Config.StatusFname
-	if fname == "" {
-		return
-	}
-
-	blob, _ := json.MarshalIndent(t.workspaces, "", "    ")
-	os.Create(fname)
-	err := os.WriteFile(fname, blob, 0600)
-	if err != nil {
-		log.Fatal(err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
+	"os"
 
 	"github.com/BurntSushi/xgbutil/xevent"
 	"github.com/blrsn/zentile/state"
@@ -30,6 +32,20 @@ func main() {
 
 	// Run X event loop
 	xevent.Main(state.X)
+}
+
+func generateStatus(t *tracker) {
+	fname := Config.StatusFname
+	if fname == "" {
+		return
+	}
+
+	blob, _ := json.MarshalIndent(t.workspaces, "", "    ")
+	os.Create(fname)
+	err := os.WriteFile(fname, blob, 0600)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func setLogLevel() {


### PR DESCRIPTION
configure a filename to use and zentile will print something like this when it starts up or changes tiling state for a workspace.  Other apps can monitor changes to this file if they desire to track changes or indicate state.

Fixes #25 

```
{
    "0": {
        "IsTiling": false
    },
    "1": {
        "IsTiling": true
    }
}
```