### PR TITLE
Tile workspaces at startup

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,7 +17,8 @@ type cfg struct {
 	WindowsToIgnore []string `toml:"ignore"`
 	Gap             int
 	Proportion      float64
-	HideDecor       bool `toml:"remove_decorations"`
+	HideDecor       bool  `toml:"remove_decorations"`
+	TileStartup     []int `toml:"tile_workspaces"`
 }
 
 func init() {
@@ -69,6 +70,10 @@ gap = 5
 
 # How much to increment the master area size.
 proportion = 0.1
+
+# tile on startup (optional)
+# list of workspace numbers to activate tiling for at startup
+# tile_workspaces = [0, 1, 3]
 
 [keybindings]
 # key sequences can have zero or more modifiers and exactly one key.

--- a/main.go
+++ b/main.go
@@ -15,6 +15,18 @@ func main() {
 	t := initTracker(CreateWorkspaces())
 	bindKeys(t)
 
+	startups := Config.TileStartup
+	for i := 0; i < len(startups); i += 1 {
+		ws := startups[i]
+		if ws >= len(t.workspaces) {
+			log.Warn("Invalid workspace number in tile_workspaces: ", ws)
+			continue
+		}
+
+		t.workspaces[uint(ws)].IsTiling = true
+		t.workspaces[uint(ws)].Tile()
+	}
+
 	// Run X event loop
 	xevent.Main(state.X)
 }

--- a/main.go
+++ b/main.go
@@ -17,14 +17,15 @@ func main() {
 
 	startups := Config.TileStartup
 	for i := 0; i < len(startups); i += 1 {
-		ws := startups[i]
-		if ws >= len(t.workspaces) {
-			log.Warn("Invalid workspace number in tile_workspaces: ", ws)
+		wn := startups[i]
+		ws := t.workspaces[uint(wn)]
+		if wn >= len(t.workspaces) {
+			log.Warn("Invalid workspace number in tile_workspaces: ", wn)
 			continue
 		}
 
-		t.workspaces[uint(ws)].IsTiling = true
-		t.workspaces[uint(ws)].Tile()
+		ws.IsTiling = true
+		ws.Tile()
 	}
 
 	// Run X event loop


### PR DESCRIPTION
adds a config option for choosing which spaces should have tiling enabled by default when zentile starts up